### PR TITLE
다크 모드 끄기

### DIFF
--- a/TimeStop/TimeStopApp.swift
+++ b/TimeStop/TimeStopApp.swift
@@ -12,6 +12,7 @@ struct TimeStopApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .preferredColorScheme(.light)
         }
     }
 }


### PR DESCRIPTION
## Summary
- 앱을 라이트 모드로 고정하여 다크 모드 영향 제거
- 타이머 실행 중 동적 다크 모드 전환 제거

## Changes
- `TimeStopApp.swift`: `.preferredColorScheme(.light)` 추가로 앱 전체 라이트 모드 강제
- `TimerScreen.swift`: 타이머 실행 중 다크 모드 전환 코드 제거

## Test plan
- [x] 빌드 성공 확인
- [x] 시스템 다크 모드 ON 상태에서 앱이 라이트 모드로 표시되는지 확인
- [x] 타이머 실행 중 화면이 라이트 모드로 유지되는지 확인

Closes JAE-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 타이머 준비 상태에 동적 반짝임 효과 추가
  * 타이머 실행 중 0.5초 후 깜박이는 중지 지시문 표시
  * 앱 전체 라이트 모드 적용으로 개선된 시각 일관성

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->